### PR TITLE
refactor : 사진 업로드 중복로직 수정

### DIFF
--- a/src/app/flows/upload-file-flow.tsx
+++ b/src/app/flows/upload-file-flow.tsx
@@ -38,6 +38,8 @@ export const handleUpload = async (params: Params, { form, setForm }: DistrictFl
         })
         .then((response) => {
           setForm({ district: params.userInput, image: params.file })
+          console.log(form.district)
+
           form.district = ''
           return response
         })
@@ -118,35 +120,6 @@ export const uploadFileFlow = ({ form, setForm }: DistrictFlowProps) => ({
     },
     path: 'uploadFile_end',
   },
-
-  // re_upload: {
-  //   message: '다른 사진을 업로드 해주세요!',
-  //   chatDisabled: true,
-  //   file: async (params: Params) => {
-  //     try {
-  //       const file = params?.files?.[0] as File
-  //       const image: string = await new Promise((resolve, reject) => {
-  //         Resizer.imageFileResizer(
-  //           file, // 원본 파일
-  //           640, // 최대 가로 너비
-  //           640, // 최대 세로 높이
-  //           'JPEG', // 변환할 이미지 포맷
-  //           100, // 품질
-  //           0, // 회전
-  //           (image) => {
-  //             resolve(image as string)
-  //           },
-  //           'base64' // 출력 타입
-  //         )
-  //       })
-  //       setForm((form) => ({ ...form, file: image }))
-  //       return image
-  //     } catch (error) {
-  //       console.error('Error resizing the image:', error)
-  //     }
-  //   },
-  //   path: 'uploadFile_end',
-  // },
 
   uploadFile_end: {
     streamSpeed: 10,


### PR DESCRIPTION
### 최근 작업 주제
- [ ] 기능 추가
- [ ] 디자인 수정 
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 필요한 주석 및 추가 변경
- [ ] 빌드 업데이트, 패키지 매니저 수정 
- [ ] 파일명 수정 및 옮기기
- [ ] 파일 삭제 

### 상세 내용
- 처음 사진을 업로드 하고 두번 째 이후 사진을 업로드 할 때, 처음 업로드 하는 함수인 uploadFile_start 로직을 재활용 